### PR TITLE
Update supported-codecs.md: The word Windows in Windows 10 IOT was in…

### DIFF
--- a/uwp/audio-video-camera/supported-codecs.md
+++ b/uwp/audio-video-camera/supported-codecs.md
@@ -617,7 +617,7 @@ The following tables show the audio codec and format support for each device fam
 
  
 
-### WIndows 10 IoT
+### Windows 10 IoT
 
 <table>
 <colgroup>


### PR DESCRIPTION
…correctly cased WIndows

In one spot, the word Windows had the letter "i" capitalized. This appears to be the typo; in other places in the learn.microsoft.com site, Windows is spelled with a lower-case letter i.