### PR TITLE
Share docs Phase 1: fix over-broad share-target sample, add anti-patterns, cross-link People API

### DIFF
--- a/hub/apps/develop/windows-integration/integrate-sharesheet-overview.md
+++ b/hub/apps/develop/windows-integration/integrate-sharesheet-overview.md
@@ -23,11 +23,13 @@ In this comprehensive guide, you'll learn how to add the share feature to your p
 | [Integrate packaged apps with Windows Share](integrate-sharesheet-packaged.md) | Discover how to integrate packaged apps with the Windows Share Sheet. |
 | [Integrate Progressive Web Apps (PWAs) with Windows Share](integrate-sharesheet-pwa.md) | Discover how to integrate a Progressive Web App (PWA) with the Windows Share Sheet. |
 | [Integrate unpackaged apps with Windows Share](integrate-sharesheet-unpackaged.md) | Discover how to integrate unpackaged apps with the Windows Share Sheet. |
+| [Surface your app as a contact share target (People on Windows)](cross-device-people-api.md) | Make your app appear in the people row of the Share Sheet by donating contacts with the Cross-Device People API. |
 | [Share data - WinUI apps](/windows/apps/develop/windows-integration/integrate-sharesheet-overview) | Learn how to share data between WinUI apps. |
 
 ## See also
 
 - [Communication - Windows apps](/windows/apps/develop/communication/)
+- [People on Windows: surface your app as a contact share target](cross-device-people-api.md)
 - [Windows App SDK deployment overview](/windows/apps/package-and-deploy/deploy-overview)
 - [Create your first WinUI project](/windows/apps/winui/winui3/create-your-first-winui3-app)
 - [Migrate from UWP to the Windows App SDK](/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/migrate-to-windows-app-sdk-ovw)

--- a/hub/apps/develop/windows-integration/integrate-sharesheet-packaged.md
+++ b/hub/apps/develop/windows-integration/integrate-sharesheet-packaged.md
@@ -31,21 +31,30 @@ There are two steps required to implement the Share contract in your app.
 
 In Visual Studio's Solution Explorer, open the `package.appxmanifest` file of the Packaging project in your solution and add the share target extension.
 
+> [!IMPORTANT]
+> Declare only the specific file types and data formats that your app can actually handle. Avoid `<uap:SupportsAnyFileType />` unless your app is a general-purpose file mover (for example, a cloud storage or file-transfer app). Registering for every file type makes your app appear as a share target for content it can't use—for example, a photo editor showing up for spreadsheets—which is the single most common share-target bug. For more guidance, see [Common share-target mistakes](#common-share-target-mistakes).
+
+The following example registers a share target for an app that receives images. It declares the specific image extensions the app supports rather than every file type.
+
 ```xml
 <Extensions>
-      <uap:Extension
-          Category="windows.shareTarget">
-        <uap:ShareTarget>
-          <uap:SupportedFileTypes>
-            <uap:SupportsAnyFileType />
-          </uap:SupportedFileTypes>
-          <uap:DataFormat>Bitmap</uap:DataFormat>
-        </uap:ShareTarget>
-      </uap:Extension>
+<uap:Extension
+Category="windows.shareTarget">
+<uap:ShareTarget>
+<uap:SupportedFileTypes>
+<uap:FileType>.jpg</uap:FileType>
+<uap:FileType>.jpeg</uap:FileType>
+<uap:FileType>.png</uap:FileType>
+<uap:FileType>.gif</uap:FileType>
+<uap:FileType>.bmp</uap:FileType>
+</uap:SupportedFileTypes>
+<uap:DataFormat>Bitmap</uap:DataFormat>
+</uap:ShareTarget>
+</uap:Extension>
 </Extensions>
 ```
 
-Add the supported data format that is supported by your application to the `DataFormat` configuration. In this case, the app supports sharing images, so the `DataFormat` is set to `Bitmap`.
+Add the data formats that your application supports to the `DataFormat` configuration. In this example, the app receives images, so it declares the image file extensions it supports and sets the `DataFormat` to `Bitmap`. Always declare the narrowest set of file types and data formats that your app can handle.
 
 ### Fetch Share Event arguments
 
@@ -119,6 +128,17 @@ static async void HandleShareAsync(ShareTargetActivatedEventArgs args)
     // app launch code
 }
 ```
+
+## Common share-target mistakes
+
+Most share-target bugs come from declaring more than your app can handle, or from not validating what you receive. Review these anti-patterns before you ship:
+
+| Anti-pattern | Fix |
+|--|--|
+| Declaring `<uap:SupportsAnyFileType />` so your app appears for every file. | Declare specific extensions—for example, `<uap:FileType>.jpg</uap:FileType>` and `<uap:FileType>.png</uap:FileType>`. Reserve `SupportsAnyFileType` for general-purpose file movers. |
+| Forgetting to declare `Uri` for link-handling apps, so your app is missing when a user shares a link. | If your app handles links, declare `<uap:DataFormat>Uri</uap:DataFormat>` (and on the sending side, populate the share with [SetWebLink](/uwp/api/windows.applicationmodel.datatransfer.datapackage.setweblink)). |
+| Skipping `Bitmap` for image-receiving apps. | Image apps should declare both `<uap:DataFormat>Bitmap</uap:DataFormat>` and `<uap:DataFormat>StorageItems</uap:DataFormat>`, because images can arrive as either. |
+| Not validating shared content at runtime. | In your activation handler, confirm the data format is present and check the content (for example, file size and type) before you process it. |
 
 ## See also
 

--- a/uwp/app-to-app/receive-data.md
+++ b/uwp/app-to-app/receive-data.md
@@ -31,6 +31,9 @@ Next, decide what file types and data formats you support. The Share APIs suppor
 
 Only register for formats that your app can handle. Only target apps that support the data being shared appear when the user invokes Share.
 
+> [!IMPORTANT]
+> Declare only the specific file types and data formats your app can handle. Use **SupportsAnyFileType** only if your app is a general-purpose file mover (for example, a cloud storage or file-transfer app). Registering for all file types makes your app appear as a share target for content it can't use, which is the most common share-target bug. For link-handling apps, remember to declare the **Uri** data format; for image apps, declare both **Bitmap** and **StorageItems**. Always validate the format and size of received content in your activation handler before processing it.
+
 To set file types:
 
 1.  Open the manifest file. It should be called something like **package.appxmanifest**.
@@ -116,7 +119,9 @@ async void ReportCompleted(ShareOperation shareOperation, string quickLinkId, st
         Title = quickLinkTitle,
 
         // For quicklinks, the supported FileTypes and DataFormats are set 
-        // independently from the manifest
+        // independently from the manifest. Declare only the types this
+        // QuickLink can handle rather than "*" unless your app is a
+        // general-purpose file mover.
         SupportedFileTypes = { "*" },
         SupportedDataFormats = { StandardDataFormats.Text, StandardDataFormats.Uri, 
                 StandardDataFormats.Bitmap, StandardDataFormats.StorageItems }

--- a/uwp/app-to-app/share-data.md
+++ b/uwp/app-to-app/share-data.md
@@ -41,6 +41,9 @@ You can share various types of data, including:
 
 The [**DataPackage**](/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object can contain one or more of these formats, in any combination. The following example demonstrates sharing text.
 
+> [!TIP]
+> When you share a URL, use [**SetWebLink**](/uwp/api/windows.applicationmodel.datatransfer.datapackage.setweblink) (or [**SetApplicationLink**](/uwp/api/windows.applicationmodel.datatransfer.datapackage.setapplicationlink)) rather than [**SetText**](/uwp/api/windows.applicationmodel.datatransfer.datapackage.settext). This lets target apps recognize the content as a link and handle it appropriately—for example, generating a rich preview—instead of treating it as plain text.
+
 :::code language="csharp" source="~/../snippets-windows/windows-uwp/app-to-app/share_data/cs/MainPage.xaml.cs" id="SnippetSetContent":::
 
 ## Set properties


### PR DESCRIPTION
## Summary
Phase 1 of the Windows Share Sheet documentation improvements (content fixes on existing pages). Based on an internal proposal to make the Share docs task-oriented and to steer developers away from over-broad share-target declarations.

## Changes
- **integrate-sharesheet-packaged.md**: Replace the first `<uap:SupportsAnyFileType />` sample with specific image file-type declarations, add an IMPORTANT callout, and add a new **Common share-target mistakes** section (4 anti-patterns + fixes).
- **uwp/app-to-app/receive-data.md**: Add guidance cautioning against `SupportsAnyFileType` / wildcard declarations and reminding authors to validate received content.
- **uwp/app-to-app/share-data.md**: Recommend `SetWebLink`/`SetApplicationLink` over `SetText` when sharing URLs.
- **integrate-sharesheet-overview.md**: Cross-link **People on Windows** (Cross-Device People API) so developers can surface their app as a contact share target.

## Notes
- Why: the first receive sample using `SupportsAnyFileType` causes real bugs (apps appearing as share targets for content they can't handle).
- A follow-up PR (Phase 2) will restructure the information architecture to be task-based (Send / Receive / Surface as contact target) and add dedicated reference pages.