### PR TITLE
Remove `title` line to resolve template validation warnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-customer-feedback-repo.yml
+++ b/.github/ISSUE_TEMPLATE/0-customer-feedback-repo.yml
@@ -1,5 +1,4 @@
 name: "Post a general documentation issue using the repo link"
-title: ""
 description: >-
   Post an issue for Windows developer docs. Use the feedback link from the bottom of the learn.microsoft.com page to link the associated doc or this template for a general issue.
   - "needs-triage"

--- a/.github/ISSUE_TEMPLATE/1-customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/1-customer-feedback.yml
@@ -1,5 +1,4 @@
 name: "Post a documentation issue"
-title: ""
 description: >-
   Post an issue specific to Windows dev docs. ⛔ This template connects to the feedback link on the bottom of learn.microsoft.com. If posting an issue from the GitHub repo, choose a different template.⛔
 labels:


### PR DESCRIPTION
This may enable the template when visitors click the button at the bottom of a doc page, and then resolves #6035