### PR TITLE
Document PowerToys update channels

### DIFF
--- a/hub/powertoys/general.md
+++ b/hub/powertoys/general.md
@@ -1,7 +1,7 @@
 ---
 title: Configure PowerToys General Settings for Windows
 description: Configure PowerToys general settings including updates, admin mode, themes, and startup behavior. Learn how to customize your Windows PowerToys experience with our step-by-step guide.
-ms.date: 06/08/2026
+ms.date: 08/06/2026
 ms.topic: concept-article
 no-loc: [PowerToys, Windows, Insider]
 # Customer intent: As a Windows power user, I want to learn how to configure the general settings for PowerToys.
@@ -22,6 +22,8 @@ Here you can check for new updates, and if one is available, you can download an
 | Download updates automatically | When enabled, PowerToys automatically downloads available updates in the background. New installations have this enabled by default. |
 | Show new updates as toast notifications | When enabled, displays a Windows toast notification when a new update is available. |
 | Show what's new after updates | When enabled, displays a "What's New" dialog after updates are applied so you can see the latest changes. |
+
+To choose between generally available releases and nightly prerelease builds, see [PowerToys update channels](./update-channel.md).
 
 When an automatic update is applied, PowerToys restarts itself and shows a toast confirming the new version is running. Your `settings.json` and other configuration files are backed up before each update, and PowerToys restores them automatically if it detects corruption after the update.
 

--- a/hub/powertoys/grouppolicy.md
+++ b/hub/powertoys/grouppolicy.md
@@ -1,7 +1,7 @@
 ---
 title: Configure PowerToys with Group Policy Settings
 description: Learn how to configure and manage PowerToys utilities using Group Policy settings, administrative templates, and registry configurations for enterprise environments.
-ms.date: 08/20/2025
+ms.date: 08/06/2026
 ms.topic: how-to
 no-loc: [PowerToys, Windows, Group Policy, Win]
 # customer intent: As a Windows power user, I want to learn how to configure PowerToys using Group Policy settings.
@@ -197,6 +197,8 @@ This policy configures whether PowerToys experimentation is allowed. With experi
 
 ### Installer and Updates
 
+These policies control installation and update behavior. For details about stable and prerelease updates, see [PowerToys update channels](./update-channel.md).
+
 #### Disable per-user installation
 
 Supported on PowerToys 0.68.0 or later.
@@ -256,6 +258,37 @@ This policy configures whether the automatic download and installation of availa
 ##### Intune information
 
 - OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys~InstallerUpdates/DisableAutomaticUpdateDownload`
+- Example value: `<enabled/>`
+
+#### Disable preview build updates
+
+Supported on PowerToys 0.100.0 or later.
+
+This policy configures whether users can opt in to Insider preview build updates.
+
+- If enabled, PowerToys ignores the user's saved update channel preference, prevents the user from changing it, and offers only stable updates. The saved preference isn't overwritten.
+- If disabled or not configured, the user can choose whether to receive preview build updates.
+
+For more information about the effect of this policy when switching channels, see [PowerToys update channels](./update-channel.md#group-policy-behavior).
+
+##### Group Policy (ADMX) information
+
+- GP unique name: DisablePreviewUpdates
+- GP name: Disable preview build updates
+- GP path: Administrative Templates/Microsoft PowerToys/Installer and Updates
+- GP scope: Computer and user
+- ADMX file name: _PowerToys.admx_
+
+##### Registry information
+
+- Path: Software\Policies\PowerToys
+- Name: PreviewUpdatesDisabled
+- Type: DWORD
+- Example value: `0x00000001`
+
+##### Intune information
+
+- OMA-URI: `./Device/Vendor/MSFT/Policy/Config/PowerToys~Policy~PowerToys~InstallerUpdates/DisablePreviewUpdates`
 - Example value: `<enabled/>`
 
 #### Suspend Action Center notification for new updates

--- a/hub/powertoys/toc.yml
+++ b/hub/powertoys/toc.yml
@@ -7,6 +7,8 @@ items:
     items:
     - name: General settings
       href: ../powertoys/general.md
+    - name: Update channels
+      href: ../powertoys/update-channel.md
     - name: Group Policy
       href: ../powertoys/grouppolicy.md
     - name: Running as administrator

--- a/hub/powertoys/update-channel.md
+++ b/hub/powertoys/update-channel.md
@@ -1,0 +1,45 @@
+---
+title: Choose a PowerToys update channel
+description: Learn how Stable and Insider update channels work in PowerToys, how to switch channels, and how Group Policy controls preview updates.
+ms.date: 08/06/2026
+ms.topic: concept-article
+no-loc: [PowerToys, Windows, Stable, Insider]
+# Customer intent: As a PowerToys user, I want to choose between stable and nightly updates and understand the effects of switching channels.
+---
+
+# PowerToys update channels
+
+PowerToys offers two update channels. Choose a channel based on whether you prioritize release stability or early access to changes.
+
+| Channel | What you receive |
+| :--- | :--- |
+| **Stable (Recommended)** | Tested, generally available releases. Stable is the default channel. |
+| **Insider** | Nightly prerelease builds with the latest features and fixes. These builds receive less validation than stable releases and might be unstable. |
+
+Insider builds are published as GitHub prereleases. They can contain incomplete changes or regressions, so use the Stable channel on systems where reliability is important.
+
+## Change the update channel
+
+1. Open **PowerToys Settings**.
+1. Select **General**, and then expand **Update channel** under **Version & updates**.
+1. Select **Stable (Recommended)** or **Insider**.
+
+PowerToys saves your selection and checks for updates using the selected channel.
+
+## What happens when you switch
+
+When you switch to Insider, update checks include stable releases and prerelease builds. PowerToys offers the newest release with a version later than the version you have installed.
+
+When you switch to Stable, update checks include only stable releases. PowerToys doesn't downgrade or uninstall an Insider build. If your installed Insider version is newer than the latest stable release, you remain on that version until a later stable release becomes available.
+
+Switching channels doesn't reset your PowerToys settings.
+
+## Group Policy behavior
+
+Administrators can manage access to the Insider channel with the **Disable preview build updates** policy under **Administrative Templates > Microsoft PowerToys > Installer and Updates**.
+
+- If the policy is enabled, PowerToys turns off preview updates, locks the update channel control, and offers only stable updates. The policy ignores the saved user preference without overwriting it.
+- If the policy is disabled or not configured, you can choose either update channel.
+- After an administrator removes an enabled policy, PowerToys restores the previously saved channel preference.
+
+For policy identifiers and deployment details, see [PowerToys Group Policy configuration](./grouppolicy.md#disable-preview-build-updates).


### PR DESCRIPTION
## Summary

- Add a PowerToys update channel page covering Stable and Insider/nightly releases, switching behavior, risks, and Group Policy management.
- Add the page to the PowerToys settings navigation and cross-link it from General settings and Group Policy documentation.
- Document the `DisablePreviewUpdates` policy behavior introduced by microsoft/PowerToys#49414.

## Affected documentation

- https://learn.microsoft.com/windows/powertoys/update-channel
- https://learn.microsoft.com/windows/powertoys/general
- https://learn.microsoft.com/windows/powertoys/grouppolicy

## Validation

- `git diff --check`
- Targeted checks for the TOC entry, relative cross-links, changed-file scope, and `ms.date`