### PR TITLE
Document Partner Center first-submission prerequisite for Store Developer CLI

### DIFF
--- a/hub/apps/publish/msstore-dev-cli/overview-exe.md
+++ b/hub/apps/publish/msstore-dev-cli/overview-exe.md
@@ -1,7 +1,7 @@
 ---
 description: The Microsoft Store Command Line Interface for MSI/EXE apps is a cross-platform CLI that helps developers access the Microsoft Store APIs, for both managed, as well as unmanaged applications.
 title: Microsoft Store Developer CLI (MSI/EXE)
-ms.date: 11/06/2025
+ms.date: 09/08/2026
 ms.topic: article
 ms.localizationpriority: medium
 ---
@@ -13,6 +13,9 @@ ms.localizationpriority: medium
 
 The Microsoft Store Command Line Interface is a cross-platform (Windows, macOS, Linux) CLI that helps developers publish their applications to the Microsoft Store. It allows developers to locally configure their applications projects to publish to the Microsoft Store, as well as actually publish their applications' packages to the Microsoft Store, automatically calling the right [Partner Center APIs](/partner-center/develop/partner-center-rest-api-reference) to upload its packages.
 
+> [!IMPORTANT]
+> You can use the Microsoft Store Developer CLI only to update an app that is already published in the Microsoft Store. You can't use the CLI to create an app or to complete its first submission. Reserve the app's name and complete its first submission in Partner Center, and then use the CLI for later submissions. The [Microsoft Store submission API for MSI or EXE app](../store-submission-api.md) has the same requirement.
+
 The process to use Store Developer CLI is the same for both MSI/EXE and MSIX apps. So, to understand how to use it, check out the following video:
 
 >[!VIDEO https://learn-video.azurefd.net/vod/player?id=cbc4aad9-e79b-4ff6-a30b-c2399c2624a3]
@@ -23,6 +26,8 @@ To use the Microsoft Store Developer CLI, you'll need to:
 
 - [Register as a Windows app developer in Partner Center](/windows/apps/publish/partner-center/partner-center-developer-account)
 - Have a tenant associated with your Partner Center account. You can achieve that by either [associating an existing Microsoft Entra ID in Partner Center](/windows/apps/publish/partner-center/associate-existing-azure-ad-tenant-with-partner-center-account) or by [creating a new Microsoft Entra ID in Partner Center](/windows/apps/publish/partner-center/create-new-azure-ad-tenant).
+- Have your app already created in Partner Center. If your app doesn't exist yet, [create your app by reserving its name](../publish-your-app/msi/reserve-your-apps-name.md) in Partner Center. The CLI can't create an app for you.
+- Have completed the app's first submission in Partner Center. [Create one submission for the app](../publish-your-app/msi/create-app-submission.md) in Partner Center, including the [age ratings](../publish-your-app/msi/age-ratings.md) questionnaire, and publish it. After that submission is complete, you can use the CLI to create and publish later submissions for the app.
 
 ## Installation
 

--- a/hub/apps/publish/msstore-dev-cli/overview.md
+++ b/hub/apps/publish/msstore-dev-cli/overview.md
@@ -1,7 +1,7 @@
 ---
 description: The Microsoft Store Command Line Interface is a cross-platform CLI that helps developers access the Microsoft Store APIs, for both managed, as well as unmanaged applications.
 title: Microsoft Store Developer CLI (MSIX)
-ms.date: 07/27/2025
+ms.date: 09/08/2026
 ms.topic: article
 ms.localizationpriority: medium
 ---
@@ -13,6 +13,9 @@ ms.localizationpriority: medium
 
 The Microsoft Store Command Line Interface is a cross-platform (Windows, macOS, Linux) CLI that helps developers publish their applications to the Microsoft Store. It allows developers to locally configure their applications projects to publish to the Microsoft Store, as well as actually publish their applications' packages to the Microsoft Store, automatically calling the right [Partner Center APIs](/partner-center/develop/partner-center-rest-api-reference) to upload its packages.
 
+> [!IMPORTANT]
+> You can use the Microsoft Store Developer CLI only to update an app that is already published in the Microsoft Store. You can't use the CLI to create an app or to complete its first submission. Reserve the app's name and complete its first submission in Partner Center, and then use the CLI for later submissions. The [Microsoft Store submission API](/windows/uwp/monetize/create-and-manage-submissions-using-windows-store-services) has the same requirement.
+
 To understand how to use the Store Developer CLI, check out the following video:
 
 >[!VIDEO https://learn-video.azurefd.net/vod/player?id=cbc4aad9-e79b-4ff6-a30b-c2399c2624a3]
@@ -23,6 +26,8 @@ To use the Microsoft Store Developer CLI, you'll need to:
 
 - [Register as a Windows app developer in Partner Center](/windows/apps/publish/partner-center/partner-center-developer-account)
 - Have a tenant associated with your Partner Center account. You can achieve that by either [associating an existing Microsoft Entra ID in Partner Center](/windows/apps/publish/partner-center/associate-existing-azure-ad-tenant-with-partner-center-account) or by [creating a new Microsoft Entra ID in Partner Center](/windows/apps/publish/partner-center/create-new-azure-ad-tenant).
+- Have your app already created in Partner Center. If your app doesn't exist yet, [create your app by reserving its name](../publish-your-app/msix/reserve-your-apps-name.md) in Partner Center. The CLI can't create an app for you.
+- Have completed the app's first submission in Partner Center. [Create one submission for the app](../publish-your-app/msix/create-app-submission.md) in Partner Center, including the [age ratings](../publish-your-app/msix/age-ratings.md) questionnaire, and publish it. After that submission is complete, you can use the CLI to create and publish later submissions for the app.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Documents that the Microsoft Store Developer CLI can only be used to update an app that is **already published** in the Microsoft Store. The app must be reserved and its first submission completed in Partner Center before the CLI can be used.

This constraint is already documented for the [Microsoft Store submission API](https://learn.microsoft.com/windows/apps/publish/store-submission-api), but the CLI overview pages didn't mention it, which led readers to expect the CLI could create an app and drive its first submission.

## Changes

Applied to both `hub/apps/publish/msstore-dev-cli/overview.md` (MSIX) and `overview-exe.md` (MSI/EXE):

- Added an `> [!IMPORTANT]` callout after the intro stating the CLI can't create an app or complete its first submission, and pointing to the equivalent requirement in the submission API docs (MSIX → UWP submission API; MSI/EXE → `store-submission-api.md`).
- Added two **Prerequisites** bullets:
  - App must already exist in Partner Center — links to *reserve your app's name*.
  - The app's first submission, including the age ratings questionnaire, must be completed in Partner Center.
- Bumped `ms.date` on both pages.

## Notes

- Wording mirrors the existing prerequisites in `store-submission-api.md` so the CLI and API docs agree.
- Uses Learn note syntax rather than bold-text callouts, and states the limitation directly rather than softening it.
- All relative link targets (`publish-your-app/msix/*`, `publish-your-app/msi/*`) verified to exist in the repo.